### PR TITLE
Wandb logging of stats and generated conversations

### DIFF
--- a/influence_benchmark/RL/expert_iteration.py
+++ b/influence_benchmark/RL/expert_iteration.py
@@ -171,10 +171,10 @@ class ExpertIteration:
             if self.wandb:
                 wandb.log(
                     {
-                        "rew_avg_all_trajs": rew_avg_all_trajs,
-                        "rew_avg_top_trajs": rew_avg_top_trajs,
-                        "infl_avg_all_trajs": infl_avg_all_trajs,
-                        "infl_avg_top_trajs": infl_avg_top_trajs,
+                        "Avg reward": rew_avg_all_trajs,
+                        "Avg reward (top n)": rew_avg_top_trajs,
+                        "Avg influence": infl_avg_all_trajs,
+                        "Avg influence (top n)": infl_avg_top_trajs,
                     },
                     commit=True,
                 )

--- a/influence_benchmark/RL/expert_iteration.py
+++ b/influence_benchmark/RL/expert_iteration.py
@@ -9,10 +9,17 @@ from typing import Optional, Tuple
 import yaml
 from tqdm import tqdm
 
+import wandb
 from influence_benchmark.agent.agent import Agent
 from influence_benchmark.root import PROJECT_DATA, PROJECT_ROOT
-from influence_benchmark.stats.preferences_per_iteration import analyze_run, get_best_worst_n_trajectories
+from influence_benchmark.stats.preferences_per_iteration import (
+    analyze_run,
+    compute_average_traj_rewards,
+    load_trajectories,
+    process_iteration_data,
+)
 from influence_benchmark.utils.utils import load_yaml, model_name_to_backend_class
+from influence_benchmark.utils.wandb_logging import extract_wandb_data
 from influence_benchmark.vectorized_environment.environment_queue import get_environment_queue
 from influence_benchmark.vectorized_environment.vectorized_environment import VectorizedEnvironment
 
@@ -33,6 +40,7 @@ class ExpertIteration:
         run_name: Optional[str] = None,
         devices: Optional[list] = None,
         mode: str = "multi",
+        log_to_wandb: bool = False,
     ):
         accelerate_config = load_yaml(accelerate_config_path)
         gpu_ids = accelerate_config["gpu_ids"] if devices is None else devices
@@ -76,14 +84,17 @@ class ExpertIteration:
         self.training_args["output_dir"] = str(self.model_dir)
         self.training_args["data_path"] = str(self.trajectory_dir)
         self.accelerate_config_path = accelerate_config_path
-
         self.sft_script_path = sft_script_path
-
         self.n_trajs_per_initial_state = n_trajs_per_initial_state
         self.top_n_trajs_per_initial_state = top_n_trajs_per_initial_state
         self.iterations = iterations
-
         self.model_name = model_name
+
+        self.wandb = log_to_wandb
+        if self.wandb:
+            wandb.init(project="influence-benchmark", name=self.run_name)
+            wandb.config.update(kwargs_to_save)
+
         self.iteration_step = 0
 
     def create_vec_environment_and_agent(
@@ -104,12 +115,14 @@ class ExpertIteration:
     def launch(self):
         self.lora_path = None
 
-        for _ in range(self.iterations):
+        for iteration_step in range(self.iterations):
+            self.iteration_step = iteration_step
+
             # set up directories
             model_iteration_dir = self.model_dir / str(self.iteration_step)
-            trajectory_iteration_dir = self.trajectory_dir / str(self.iteration_step)
-            trajectory_iteration_dir.mkdir(parents=True, exist_ok=True)
-            selected_trajectory_fname = trajectory_iteration_dir / "selected_trajectories.jsonl"
+            traj_iteration_dir = self.trajectory_dir / str(self.iteration_step)
+            traj_iteration_dir.mkdir(parents=True, exist_ok=True)
+            selected_trajectory_fname = traj_iteration_dir / "selected_trajectories.jsonl"
 
             config_dir_or_file = PROJECT_ROOT / "config" / "env_configs" / self.env_args["env_name"]
             if config_dir_or_file.is_dir():
@@ -130,7 +143,7 @@ class ExpertIteration:
                     print(f"Running process on device {device}")
                 p = mp.Process(
                     target=self.generate_trajectories,  # code to run in parallel
-                    args=(shared_queue, progress, device, trajectory_iteration_dir, agent_config),
+                    args=(shared_queue, progress, device, traj_iteration_dir, agent_config),
                 )
                 p.start()
                 processes.append(p)
@@ -150,10 +163,35 @@ class ExpertIteration:
             pbar.close()
 
             # format trajectories for RL training
-            top_trajectories, _ = get_best_worst_n_trajectories(
-                trajectory_iteration_dir, self.top_n_trajs_per_initial_state
+            top_trajs, n_trajs, rew_avg_all_trajs, rew_avg_top_trajs, infl_avg_all_trajs, infl_avg_top_trajs = (
+                process_iteration_data(traj_iteration_dir, self.top_n_trajs_per_initial_state)
             )
-            self.format_and_save_trajectories_for_sft(top_trajectories, trajectory_iteration_dir)
+            if self.wandb:
+                # TODO: clean this up, currently pretty ugly
+                wandb.log(
+                    {
+                        "rew_avg_all_trajs": rew_avg_all_trajs,
+                        "rew_avg_top_trajs": rew_avg_top_trajs,
+                        "infl_avg_all_trajs": infl_avg_all_trajs,
+                        "infl_avg_top_trajs": infl_avg_top_trajs,
+                    },
+                    commit=True,
+                )
+                traj_timesteps_df = load_trajectories(traj_iteration_dir)
+                avg_rew_df = compute_average_traj_rewards(traj_timesteps_df)
+                traj_timesteps_df = traj_timesteps_df.merge(
+                    avg_rew_df, on=["env_name", "initial_state_id", "trajectory_id"]
+                )
+                trajectories = extract_wandb_data(avg_rew_df)
+                for trajectory in trajectories:
+                    wandb.log(
+                        {
+                            f"trajectory_{trajectory['initial_state_id']}_{trajectory['trajectory_id']}": wandb.Html(
+                                trajectory["html_content"]
+                            )
+                        }
+                    )
+            self.format_and_save_trajectories_for_sft(top_trajs, traj_iteration_dir)
 
             # run RL training
             args = {
@@ -179,8 +217,6 @@ class ExpertIteration:
             checkpoints = [file for file in model_iteration_dir.iterdir() if file.name.startswith("checkpoint-")]
             checkpoints.sort(key=lambda x: int(x.name.split("-")[-1]))
             self.lora_path = checkpoints[-1]
-
-            self.iteration_step += 1
 
     def generate_trajectories(self, shared_queue, progress, device, traj_dir_path, agent_config):
         """

--- a/influence_benchmark/RL/expert_iteration.py
+++ b/influence_benchmark/RL/expert_iteration.py
@@ -166,8 +166,9 @@ class ExpertIteration:
             top_trajs, n_trajs, rew_avg_all_trajs, rew_avg_top_trajs, infl_avg_all_trajs, infl_avg_top_trajs = (
                 process_iteration_data(traj_iteration_dir, self.top_n_trajs_per_initial_state)
             )
+            self.format_and_save_trajectories_for_sft(top_trajs, traj_iteration_dir)
+
             if self.wandb:
-                # TODO: clean this up, currently pretty ugly
                 wandb.log(
                     {
                         "rew_avg_all_trajs": rew_avg_all_trajs,
@@ -177,6 +178,8 @@ class ExpertIteration:
                     },
                     commit=True,
                 )
+                # TODO: clean this up, currently pretty ugly
+                # The main issue is that the pandas code is not very modular rn and hard to reuse
                 traj_timesteps_df = load_trajectories(traj_iteration_dir)
                 avg_rew_df = compute_average_traj_rewards(traj_timesteps_df)
                 traj_timesteps_df = traj_timesteps_df.merge(
@@ -184,14 +187,8 @@ class ExpertIteration:
                 )
                 trajectories = extract_wandb_data(traj_timesteps_df)
                 for trajectory in trajectories:
-                    wandb.log(
-                        {
-                            f"trajectory_{trajectory['initial_state_id']}_{trajectory['trajectory_id']}": wandb.Html(
-                                trajectory["html_content"]
-                            )
-                        }
-                    )
-            self.format_and_save_trajectories_for_sft(top_trajs, traj_iteration_dir)
+                    # TODO: probably limit how many trajectories we log, just so it doesn't become too much
+                    wandb.log({f"Iteration {self.iteration_step}": wandb.Html(trajectory["html_content"])})
 
             # run RL training
             args = {

--- a/influence_benchmark/RL/expert_iteration.py
+++ b/influence_benchmark/RL/expert_iteration.py
@@ -15,11 +15,12 @@ from influence_benchmark.root import PROJECT_DATA, PROJECT_ROOT
 from influence_benchmark.stats.preferences_per_iteration import (
     analyze_run,
     compute_average_traj_rewards,
+    get_best_worst_n_trajectories,
     load_trajectories,
     process_iteration_data,
 )
 from influence_benchmark.utils.utils import load_yaml, model_name_to_backend_class
-from influence_benchmark.utils.wandb_logging import extract_wandb_data
+from influence_benchmark.utils.wandb_logging import extract_wandb_data, log_iteration_data
 from influence_benchmark.vectorized_environment.environment_queue import get_environment_queue
 from influence_benchmark.vectorized_environment.vectorized_environment import VectorizedEnvironment
 
@@ -89,7 +90,6 @@ class ExpertIteration:
         self.top_n_trajs_per_initial_state = top_n_trajs_per_initial_state
         self.iterations = iterations
         self.model_name = model_name
-        self.iteration_step = 0
 
         self.wandb = log_to_wandb
         if self.wandb:
@@ -115,11 +115,10 @@ class ExpertIteration:
         self.lora_path = None
 
         for iteration_step in range(self.iterations):
-            self.iteration_step = iteration_step
 
             # set up directories
-            model_iteration_dir = self.model_dir / str(self.iteration_step)
-            traj_iter_dir = self.trajectory_dir / str(self.iteration_step)
+            model_iteration_dir = self.model_dir / str(iteration_step)
+            traj_iter_dir = self.trajectory_dir / str(iteration_step)
             traj_iter_dir.mkdir(parents=True, exist_ok=True)
             selected_trajectory_fname = traj_iter_dir / "selected_trajectories.jsonl"
 
@@ -135,7 +134,7 @@ class ExpertIteration:
                 env_args=self.env_args, num_devices=len(self.devices), total_env=self.total_envs
             )  # the environment queue that will enable parallel execution next
 
-            pbar = tqdm(total=total_environments, desc=f"Completed environments for iteration {self.iteration_step}")
+            pbar = tqdm(total=total_environments, desc=f"Completed environments for iteration {iteration_step}")
 
             for dev_idx, device in enumerate(self.devices):
                 if DEBUG:
@@ -162,37 +161,16 @@ class ExpertIteration:
             pbar.close()
 
             # format trajectories for RL training
-            top_trajs, n_trajs, rew_avg_all_trajs, rew_avg_top_trajs, infl_avg_all_trajs, infl_avg_top_trajs = (
-                process_iteration_data(traj_iter_dir, self.top_n_trajs_per_initial_state)
-            )
+            top_trajs, _ = get_best_worst_n_trajectories(traj_iter_dir, self.top_n_trajs_per_initial_state)
             self.format_and_save_trajectories_for_sft(top_trajs, traj_iter_dir)
 
             if self.wandb:
-                wandb.log(
-                    {
-                        "Avg reward": rew_avg_all_trajs,
-                        "Avg reward (top n)": rew_avg_top_trajs,
-                        "Avg influence": infl_avg_all_trajs,
-                        "Avg influence (top n)": infl_avg_top_trajs,
-                    },
-                    commit=True,
-                )
-                # TODO: clean this up, currently pretty ugly, and has code re-use with KTO.py
-                # The main issue is that the pandas code is not very modular rn and hard to reuse
-                traj_timesteps_df = load_trajectories(traj_iter_dir)
-                avg_rew_df = compute_average_traj_rewards(traj_timesteps_df)
-                traj_timesteps_df = traj_timesteps_df.merge(
-                    avg_rew_df, on=["env_name", "initial_state_id", "trajectory_id"]
-                )
-                trajectories = extract_wandb_data(traj_timesteps_df)
-                for trajectory in trajectories:
-                    # TODO: probably limit how many trajectories we log, just so it doesn't become too much
-                    wandb.log({f"Iteration {self.iteration_step}": wandb.Html(trajectory["html_content"])})
+                log_iteration_data(iteration_step, self.top_n_trajs_per_initial_state, traj_iter_dir)
 
             # run RL training
             args = {
                 **self.training_args,
-                "iteration": self.iteration_step,
+                "iteration": iteration_step,
                 "output_dir": str(model_iteration_dir),
                 "data_path": str(selected_trajectory_fname),
                 "lora_path": self.lora_path,

--- a/influence_benchmark/RL/expert_iteration.py
+++ b/influence_benchmark/RL/expert_iteration.py
@@ -182,7 +182,7 @@ class ExpertIteration:
                 traj_timesteps_df = traj_timesteps_df.merge(
                     avg_rew_df, on=["env_name", "initial_state_id", "trajectory_id"]
                 )
-                trajectories = extract_wandb_data(avg_rew_df)
+                trajectories = extract_wandb_data(traj_timesteps_df)
                 for trajectory in trajectories:
                     wandb.log(
                         {

--- a/influence_benchmark/RL/expert_iteration.py
+++ b/influence_benchmark/RL/expert_iteration.py
@@ -6,10 +6,10 @@ import time
 from datetime import datetime
 from typing import Optional, Tuple
 
+import wandb
 import yaml
 from tqdm import tqdm
 
-import wandb
 from influence_benchmark.agent.agent import Agent
 from influence_benchmark.root import PROJECT_DATA, PROJECT_ROOT
 from influence_benchmark.stats.preferences_per_iteration import (

--- a/influence_benchmark/experiments/KTO_experiment.py
+++ b/influence_benchmark/experiments/KTO_experiment.py
@@ -8,16 +8,18 @@ if __name__ == "__main__":
 
 
 def main():
+    testing = True
     env_name = "therapist"
-    max_turns = 5
-    num_envs_per_device = 12
+    max_turns = 5 if not testing else 2
+    num_envs_per_device = 12 if not testing else 2
     # Number of trajectories to generate for each initial state configuration
-    n_trajs_per_initial_state = 10
+    n_trajs_per_initial_state = 10 if not testing else 2
     # Number of trajectories to select as 'best' for each initial state configuration
-    top_n_trajs_per_initial_state = 1
-    iterations = 7
+    top_n_trajs_per_initial_state = 1 if not testing else 1
+    iterations = 7 if not testing else 3
     run_name = None
     devices = [0]
+    log_to_wandb = False
 
     env_args = {
         "env_name": env_name,
@@ -66,6 +68,7 @@ def main():
         iterations=iterations,
         run_name=run_name,
         devices=devices,
+        log_to_wandb=log_to_wandb,
     )
 
     kto.launch()

--- a/influence_benchmark/experiments/KTO_experiment.py
+++ b/influence_benchmark/experiments/KTO_experiment.py
@@ -11,9 +11,9 @@ def main():
     testing = True
     env_name = "therapist"
     max_turns = 5 if not testing else 2
-    num_envs_per_device = 12 if not testing else 2
+    num_envs_per_device = 12 if not testing else 12
     # Number of trajectories to generate for each initial state configuration
-    n_trajs_per_initial_state = 10 if not testing else 2
+    n_trajs_per_initial_state = 10 if not testing else 10
     # Number of trajectories to select as 'best' for each initial state configuration
     top_n_trajs_per_initial_state = 1 if not testing else 1
     iterations = 7 if not testing else 3

--- a/influence_benchmark/experiments/single_expert_iteration_experiment.py
+++ b/influence_benchmark/experiments/single_expert_iteration_experiment.py
@@ -8,20 +8,23 @@ if __name__ == "__main__":
 
 
 def main():
+    # Run with testing=True to test the script with fewer trajectories and iterations
+    testing = True
     # Specify settings for generating trajectories
     env_name = "smoking"  # "smoking_3rdperson"
-    max_turns = 5  # number of back and forths in each conversation
-    num_envs_per_device = 8  # number of environment slots to be filled with env-subenv-initialstate combinations. For this "single" script, we just vary initialstates # 8 is roughly max
+    max_turns = 5 if not testing else 2  # number of back and forths in each conversation
+    num_envs_per_device = 2  # number of environment slots to be filled with env-subenv-initialstate combinations. For this "single" script, we just vary initialstates # 8 is roughly max
     # Number of trajectories to generate for each initial state configuration
-    n_trajs_per_initial_state = 32
+    n_trajs_per_initial_state = 32 if not testing else 2
     # Number of trajectories to select as 'best' for each initial state configuration
-    top_n_trajs_per_initial_state = 4  # on a single GPU across all trajactories
-    iterations = 5
+    top_n_trajs_per_initial_state = 4 if not testing else 1  # on a single GPU across all trajactories
+    iterations = 5 if not testing else 3
     ignore_first_n_assistant_messages = 1  # Number of assistant messages to not train on
     run_name = None
     # GPUs used for generating trajectories. The GPUs used for training are specified in the accelerate_config.yaml file.
-    devices = [2]
+    devices = [3]
     mode = "single"  # parallel implementation of running on single environment, which is more parallelized and faster than running "multi" with only a single environment specified
+    log_to_wandb = True
 
     assert n_trajs_per_initial_state >= top_n_trajs_per_initial_state
 
@@ -70,6 +73,7 @@ def main():
         run_name=run_name,
         devices=devices,
         mode=mode,
+        log_to_wandb=log_to_wandb,
     )
 
     expert_iteration.launch()

--- a/influence_benchmark/experiments/single_expert_iteration_experiment.py
+++ b/influence_benchmark/experiments/single_expert_iteration_experiment.py
@@ -11,9 +11,11 @@ def main():
     # Run with testing=True to test the script with fewer trajectories and iterations
     testing = True
     # Specify settings for generating trajectories
-    env_name = "smoking"  # "smoking_3rdperson"
-    max_turns = 5 if not testing else 2  # number of back and forths in each conversation
-    num_envs_per_device = 2  # number of environment slots to be filled with env-subenv-initialstate combinations. For this "single" script, we just vary initialstates # 8 is roughly max
+    env_name = "smoking"
+    # number of back and forths in each conversation
+    max_turns = 5 if not testing else 2
+    # number of environment slots to be filled with env-subenv-initialstate combinations. For this "single" script, we just vary initialstates # 8 is roughly max
+    num_envs_per_device = 8 if not testing else 2
     # Number of trajectories to generate for each initial state configuration
     n_trajs_per_initial_state = 32 if not testing else 2
     # Number of trajectories to select as 'best' for each initial state configuration

--- a/influence_benchmark/stats/plot_prefs_per_iteration.py
+++ b/influence_benchmark/stats/plot_prefs_per_iteration.py
@@ -40,20 +40,20 @@ def main():
 
     (
         valid_iterations,
-        all_reward_avg_all_trajectories,
-        all_reward_avg_selected_trajectories,
-        all_influence_score_avg_all_trajectories,
-        all_influence_score_avg_selected_trajectories,
+        all_rew_avg_all_trajs,
+        all_rew_avg_select_trajs,
+        all_infl_avg_all_trajs,
+        all_infl_avg_select_trajs,
     ) = analyze_run(run_name, top_n, print_out=True)
 
-    if not all_reward_avg_all_trajectories:
+    if not all_rew_avg_all_trajs:
         print("No valid data found for any iteration.")
     else:
         plot_preferences(
             run_name,
             valid_iterations,
-            all_reward_avg_all_trajectories,
-            all_reward_avg_selected_trajectories,
+            all_rew_avg_all_trajs,
+            all_rew_avg_select_trajs,
             top_n,
             label="Preference",
         )
@@ -61,8 +61,8 @@ def main():
         plot_preferences(
             run_name,
             valid_iterations,
-            all_influence_score_avg_all_trajectories,
-            all_influence_score_avg_selected_trajectories,
+            all_infl_avg_all_trajs,
+            all_infl_avg_select_trajs,
             top_n,
             label="Influence_score",
         )
@@ -70,17 +70,13 @@ def main():
         print("\nSummary:")
 
         print(f"Valid Iterations: {valid_iterations}")
-        print(f"Reward average all trajectories: {[round(pref, 3) for pref in all_reward_avg_all_trajectories]}")
+        print(f"Reward average all trajectories: {[round(pref, 3) for pref in all_rew_avg_all_trajs]}")
+        if top_n > 0:
+            print(f"Reward average Top {top_n} Trajectories: {[round(pref, 3) for pref in all_rew_avg_select_trajs]}")
+        print(f"Influence score average all trajectories: {[round(pref, 3) for pref in all_infl_avg_all_trajs]}")
         if top_n > 0:
             print(
-                f"Reward average Top {top_n} Trajectories: {[round(pref, 3) for pref in all_reward_avg_selected_trajectories]}"
-            )
-        print(
-            f"Influence score average all trajectories: {[round(pref, 3) for pref in all_influence_score_avg_all_trajectories]}"
-        )
-        if top_n > 0:
-            print(
-                f"Influence score average Top {top_n} Trajectories: {[round(pref, 3) for pref in all_influence_score_avg_selected_trajectories]}"
+                f"Influence score average Top {top_n} Trajectories: {[round(pref, 3) for pref in all_infl_avg_select_trajs]}"
             )
 
 

--- a/influence_benchmark/stats/preferences_per_iteration.py
+++ b/influence_benchmark/stats/preferences_per_iteration.py
@@ -30,9 +30,9 @@ def compute_average_traj_rewards(traj_timestep_df):
 
 
 def get_best_worst_n_trajectories(traj_path: Path, num_chosen_trajs: int) -> Tuple[List[Dict], List[Dict]]:
-    top_n_df = get_func_n_trajectories(traj_path, num_chosen_trajs, pd.DataFrame.nlargest)
-    bottom_n_df = get_func_n_trajectories(traj_path, num_chosen_trajs, pd.DataFrame.nsmallest)
-    return top_n_df, bottom_n_df
+    top_n_dict = get_func_n_trajectories(traj_path, num_chosen_trajs, pd.DataFrame.nlargest)
+    bottom_n_dict = get_func_n_trajectories(traj_path, num_chosen_trajs, pd.DataFrame.nsmallest)
+    return top_n_dict, bottom_n_dict
 
 
 def get_func_n_trajectories(
@@ -90,20 +90,24 @@ def process_iteration_data(trajectory_path: Path, top_n: int) -> Optional[Tuple[
     if next(trajectory_path.iterdir(), None) is None:
         return None
 
-    top_n_trajs_df, _ = get_best_worst_n_trajectories(trajectory_path, top_n)
+    top_n_trajs_dict, _ = get_best_worst_n_trajectories(trajectory_path, top_n)
     # We have averages for each initial state configuration (from the above function), and now we want to average across them
-    rew_avg_all_trajs = sum(traj["avg_rew_across_trajs_with_init_s"] for traj in top_n_trajs_df) / len(top_n_trajs_df)
-    rew_avg_top_trajs = sum(traj["avg_rew_across_top_trajs_with_init_s"] for traj in top_n_trajs_df) / len(
-        top_n_trajs_df
+    rew_avg_all_trajs = sum(traj["avg_rew_across_trajs_with_init_s"] for traj in top_n_trajs_dict) / len(
+        top_n_trajs_dict
+    )
+    rew_avg_top_trajs = sum(traj["avg_rew_across_top_trajs_with_init_s"] for traj in top_n_trajs_dict) / len(
+        top_n_trajs_dict
     )
 
-    infl_avg_all_trajs = sum(traj["avg_infl_across_trajs_with_init_s"] for traj in top_n_trajs_df) / len(top_n_trajs_df)
-    infl_avg_top_trajs = sum(traj["avg_infl_across_top_trajs_with_init_s"] for traj in top_n_trajs_df) / len(
-        top_n_trajs_df
+    infl_avg_all_trajs = sum(traj["avg_infl_across_trajs_with_init_s"] for traj in top_n_trajs_dict) / len(
+        top_n_trajs_dict
+    )
+    infl_avg_top_trajs = sum(traj["avg_infl_across_top_trajs_with_init_s"] for traj in top_n_trajs_dict) / len(
+        top_n_trajs_dict
     )
 
-    n_trajs = sum(traj["n_trajectories"] for traj in top_n_trajs_df)
-    return top_n_trajs_df, n_trajs, rew_avg_all_trajs, rew_avg_top_trajs, infl_avg_all_trajs, infl_avg_top_trajs
+    n_trajs = sum(traj["n_trajectories"] for traj in top_n_trajs_dict)
+    return top_n_trajs_dict, n_trajs, rew_avg_all_trajs, rew_avg_top_trajs, infl_avg_all_trajs, infl_avg_top_trajs
 
 
 def analyze_run(

--- a/influence_benchmark/stats/preferences_per_iteration.py
+++ b/influence_benchmark/stats/preferences_per_iteration.py
@@ -8,43 +8,48 @@ from influence_benchmark.root import PROJECT_DATA
 
 def load_trajectories(trajectory_path: Path) -> pd.DataFrame:
     # Read all trajectories from files
-    traj_timesteps = pd.concat([pd.read_json(file, lines=True) for file in trajectory_path.glob("[0-9]*.jsonl")])
+    traj_timestep_df = pd.concat([pd.read_json(file, lines=True) for file in trajectory_path.glob("[0-9]*.jsonl")])
 
     # Calculate expected preference
-    traj_timesteps["timestep_reward"] = traj_timesteps["preferences"].apply(calculate_expectation)
-    traj_timesteps["timestep_influence_level"] = traj_timesteps["influence_scores"].apply(calculate_expectation)
-    return traj_timesteps
+    traj_timestep_df["timestep_reward"] = traj_timestep_df["preferences"].apply(calculate_expectation)
+    traj_timestep_df["timestep_influence_level"] = traj_timestep_df["influence_scores"].apply(calculate_expectation)
+    return traj_timestep_df
 
 
-def get_best_worst_n_trajectories(traj_path: Path, num_chosen_trajs: int) -> Tuple[List[Dict], List[Dict]]:
-    top_n = get_func_n_trajectories(traj_path, num_chosen_trajs, pd.DataFrame.nlargest)
-    bottom_n = get_func_n_trajectories(traj_path, num_chosen_trajs, pd.DataFrame.nsmallest)
-    return top_n, bottom_n
-
-
-def get_func_n_trajectories(
-    trajectory_path: Path, n_chosen_trajs: int, func, return_last_turn_only: bool = False
-) -> List[Dict]:
-    # Load all trajectories from files
-    trajs = load_trajectories(trajectory_path)
-
-    # Add default values for env_name and initial_state_id if not present
-    trajs["env_name"] = trajs.get("env_name", "default")
-    trajs["initial_state_id"] = trajs.get("initial_state_id", 0)
-
+def compute_average_traj_rewards(traj_timestep_df):
     # Average over turns, will include num_envs * num_initial_states * num_trajs_per_initial_state rows
-    avg_rewards = (
-        trajs.groupby(["env_name", "initial_state_id", "trajectory_id"])[
+    avg_rewards_df = (
+        traj_timestep_df.groupby(["env_name", "initial_state_id", "trajectory_id"])[
             ["timestep_reward", "timestep_influence_level"]
         ]
         .mean()
         .reset_index()
         .rename(columns={"timestep_reward": "traj_mean_rew", "timestep_influence_level": "traj_mean_infl"})
     )
+    return avg_rewards_df
+
+
+def get_best_worst_n_trajectories(traj_path: Path, num_chosen_trajs: int) -> Tuple[List[Dict], List[Dict]]:
+    top_n_df = get_func_n_trajectories(traj_path, num_chosen_trajs, pd.DataFrame.nlargest)
+    bottom_n_df = get_func_n_trajectories(traj_path, num_chosen_trajs, pd.DataFrame.nsmallest)
+    return top_n_df, bottom_n_df
+
+
+def get_func_n_trajectories(
+    trajectory_path: Path, n_chosen_trajs: int, func, return_last_turn_only: bool = False
+) -> List[Dict]:
+    # Load all trajectories from files
+    traj_timestep_df = load_trajectories(trajectory_path)
+
+    # Add default values for env_name and initial_state_id if not present
+    traj_timestep_df["env_name"] = traj_timestep_df.get("env_name", "default")
+    traj_timestep_df["initial_state_id"] = traj_timestep_df.get("initial_state_id", 0)
+
+    avg_rewards_df = compute_average_traj_rewards(traj_timestep_df)
 
     # Select top N trajectories for each env_name and initial_state_id, reduces to num_envs * num_initial_states rows
-    top_n = (
-        avg_rewards.groupby(["env_name", "initial_state_id"])
+    top_n_df = (
+        avg_rewards_df.groupby(["env_name", "initial_state_id"])
         .apply(
             lambda x: x.assign(
                 n_trajectories=len(x),
@@ -55,19 +60,19 @@ def get_func_n_trajectories(
         .reset_index(drop=True)
     )
 
-    top_n = top_n.assign(
-        avg_rew_across_top_trajs_with_init_s=top_n["traj_mean_rew"],
-        avg_infl_across_top_trajs_with_init_s=top_n["traj_mean_infl"],
+    top_n_df = top_n_df.assign(
+        avg_rew_across_top_trajs_with_init_s=top_n_df["traj_mean_rew"],
+        avg_infl_across_top_trajs_with_init_s=top_n_df["traj_mean_infl"],
     ).drop(columns=["traj_mean_rew", "traj_mean_infl"])
 
     # Merge with original trajectories and select the longest for each group
-    best_merged = pd.merge(trajs, top_n, on=["env_name", "initial_state_id", "trajectory_id"])
+    best_merged_df = pd.merge(traj_timestep_df, top_n_df, on=["env_name", "initial_state_id", "trajectory_id"])
     if return_last_turn_only:
-        best_merged = best_merged.loc[
-            best_merged.groupby(["env_name", "initial_state_id", "trajectory_id"])["turn"].idxmax()
+        best_merged_df = best_merged_df.loc[
+            best_merged_df.groupby(["env_name", "initial_state_id", "trajectory_id"])["turn"].idxmax()
         ]
 
-    return best_merged.to_dict("records")
+    return best_merged_df.to_dict("records")
 
 
 def calculate_expectation(score_distribution: Dict[str, float]) -> float:
@@ -78,28 +83,31 @@ def calculate_expectation(score_distribution: Dict[str, float]) -> float:
 def process_iteration_data(trajectory_path: Path, top_n: int) -> Optional[Tuple[int, float, float, float, float]]:
     """Process data for a single iteration.
     Returns
-        n_trajectories: number of trajectories in the iteration
+        top_n_trajs_df: data for the top n trajectories
+        n_trajs: number of trajectories in the iteration
         rew_avg_all_trajs: reward values averaged over all trajectories
         rew_avg_top_trajs: reward value averaged over the top n trajectories
         infl_avg_all_trajs: influence score values averaged over all trajectories
         infl_avg_top_trajs: influence score value averaged over the top n trajectories
-
     """
     # Check if there are any trajectories
     if next(trajectory_path.iterdir(), None) is None:
         return None
 
-    top_n_trajs, _ = get_best_worst_n_trajectories(trajectory_path, top_n)
+    top_n_trajs_df, _ = get_best_worst_n_trajectories(trajectory_path, top_n)
     # We have averages for each initial state configuration (from the above function), and now we want to average across them
-    rew_avg_all_trajs = sum(traj["avg_rew_across_trajs_with_init_s"] for traj in top_n_trajs) / len(top_n_trajs)
-    rew_avg_top_trajs = sum(traj["avg_rew_across_top_trajs_with_init_s"] for traj in top_n_trajs) / len(top_n_trajs)
+    rew_avg_all_trajs = sum(traj["avg_rew_across_trajs_with_init_s"] for traj in top_n_trajs_df) / len(top_n_trajs_df)
+    rew_avg_top_trajs = sum(traj["avg_rew_across_top_trajs_with_init_s"] for traj in top_n_trajs_df) / len(
+        top_n_trajs_df
+    )
 
-    infl_avg_all_trajs = sum(traj["avg_infl_across_trajs_with_init_s"] for traj in top_n_trajs) / len(top_n_trajs)
-    infl_avg_top_trajs = sum(traj["avg_infl_across_top_trajs_with_init_s"] for traj in top_n_trajs) / len(top_n_trajs)
+    infl_avg_all_trajs = sum(traj["avg_infl_across_trajs_with_init_s"] for traj in top_n_trajs_df) / len(top_n_trajs_df)
+    infl_avg_top_trajs = sum(traj["avg_infl_across_top_trajs_with_init_s"] for traj in top_n_trajs_df) / len(
+        top_n_trajs_df
+    )
 
-    n_trajs = sum(traj["n_trajectories"] for traj in top_n_trajs)
-
-    return n_trajs, rew_avg_all_trajs, rew_avg_top_trajs, infl_avg_all_trajs, infl_avg_top_trajs
+    n_trajs = sum(traj["n_trajectories"] for traj in top_n_trajs_df)
+    return top_n_trajs_df, n_trajs, rew_avg_all_trajs, rew_avg_top_trajs, infl_avg_all_trajs, infl_avg_top_trajs
 
 
 def analyze_run(

--- a/influence_benchmark/utils/wandb_logging.py
+++ b/influence_benchmark/utils/wandb_logging.py
@@ -1,0 +1,108 @@
+import html
+import json
+
+import wandb
+
+
+def get_last_messages(history):
+    last_agent_message = next((msg for msg in reversed(history) if msg["role"] == "agent"), None)
+    last_environment_message = next((msg for msg in reversed(history) if msg["role"] == "environment"), None)
+    return {
+        "last_agent_message": last_agent_message["content"] if last_agent_message else None,
+        "last_environment_message": last_environment_message["content"] if last_environment_message else None,
+    }
+
+
+def format_message_html(role, content, turn):
+    role_color = "#007bff" if role == "agent" else "#28a745"
+    escaped_content = html.escape(content)
+    return f"""
+    <div style="margin-bottom: 10px;">
+        <strong style="color: {role_color};">{role.capitalize()} (turn {turn}):</strong> {escaped_content}
+    </div>
+    """
+
+
+def round_floats(obj, decimals=2):
+    if isinstance(obj, float):
+        return round(obj, decimals)
+    elif isinstance(obj, dict):
+        return {k: round_floats(v, decimals) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [round_floats(i, decimals) for i in obj]
+    return obj
+
+
+def format_stats_html(stats):
+    stats_html = "<div style='background-color: #f8f9fa; padding: 10px; margin-bottom: 10px; border-radius: 5px; display: flex; flex-wrap: wrap;'>"
+
+    # Lead with timestep reward and influence level
+    reward = round_floats(stats["Timestep Reward"])
+    influence = round_floats(stats["Timestep Influence Level"])
+    preferences = json.dumps(round_floats(stats["Preferences"]))
+    influence_scores = json.dumps(round_floats(stats["Influence Scores"]))
+
+    stats_html += f"""
+    <div style='flex: 1; min-width: 200px;'>
+        <p><strong>Reward:</strong> {reward} {preferences}</p>
+    </div>
+    <div style='flex: 1; min-width: 200px;'>
+        <p><strong>Influence:</strong> {influence} {influence_scores}</p>
+    </div>
+    """
+
+    # Add other stats
+    for key, value in stats.items():
+        if key not in ["Turn", "Timestep Reward", "Timestep Influence Level", "Preferences", "Influence Scores"]:
+            stats_html += f"<div style='flex: 1; min-width: 200px;'><p><strong>{key}:</strong> {json.dumps(round_floats(value))}</p></div>"
+
+    stats_html += "</div>"
+    return stats_html
+
+
+def extract_wandb_data(df):
+    trajectories = []
+
+    for (initial_state_id, trajectory_id), group in df.groupby(["initial_state_id", "trajectory_id"]):
+        env_name = group["env_name"].iloc[0]
+        avg_reward = round(group["traj_mean_rew"].iloc[0], 2)
+        avg_influence = round(group["traj_mean_infl"].iloc[0], 2)
+
+        trajectory_html = f"""
+        <h2>Env: {env_name} (traj_idx {trajectory_id}, init_state {initial_state_id}). AvgRew: {avg_reward}, AvgInfluence: {avg_influence}</h2>
+        """
+
+        for _, row in group.sort_values("turn").iterrows():
+            last_messages = get_last_messages(row["history"])
+            stats = {
+                "Preferences": row["preferences"],
+                "Influence Scores": row["influence_scores"],
+                "Transition Probabilities": row["transition_probs"],
+                "Timestep Reward": row["timestep_reward"],
+                "Timestep Influence Level": row["timestep_influence_level"],
+            }
+
+            trajectory_html += f"""
+            {format_stats_html(stats)}
+            {format_message_html("environment", last_messages['last_environment_message'], row['turn'])}
+            {format_message_html("agent", last_messages['last_agent_message'], row['turn'])}
+            """
+
+        trajectories.append(
+            {"initial_state_id": initial_state_id, "trajectory_id": trajectory_id, "html_content": trajectory_html}
+        )
+
+    return trajectories
+
+
+def log_to_wandb(trajectories):
+    wandb.init(project="your_project_name")
+    for trajectory in trajectories:
+        wandb.log(
+            {
+                f"trajectory_{trajectory['initial_state_id']}_{trajectory['trajectory_id']}": wandb.Html(
+                    trajectory["html_content"]
+                )
+            },
+            commit=True,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,11 @@ dev = [
 [tool.black]
 line-length = 120
 include = '\.pyi?$' # Includes .pyi stub files
-exclude = ''
+exclude = '''
+/(
+    tmp
+)
+'''
 
 # Should look into the below more
 [tool.pytest.ini_options]


### PR DESCRIPTION
Auto generating logging in real time in wandb, allowing us all to see each others runs and keep a centralized log

<img width="2115" alt="Screenshot 2024-08-03 at 4 15 36 PM" src="https://github.com/user-attachments/assets/770f682f-13aa-4409-92b2-caa31296a35d">

Thoughts:
- I removed `self.iteration_num` from EI and KTO, it didn't seem like it was being used anywhere (@carolius)
- I didn't test KTO with the wandb logging because there were no available GPUs, we should probably make a version of KTO that is very quick to run for testing. My current testing params don't really help I believe because in the multi-env setting, you just want to have as many GPUs as possible. It would be nice to be able to limit the number of initial states/envs in the queue, as to be able to quickly run testing for scripts
- I think this may supercede the GUI?