### PR TITLE
Improved config system to be able to do small deltas from other configs

### DIFF
--- a/influence_benchmark/config/experiment_config.py
+++ b/influence_benchmark/config/experiment_config.py
@@ -3,10 +3,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, TypeVar
 
 import torch
-import yaml
 
 from influence_benchmark.config.accelerate_config import AccelerateConfig, AccelerateConfigFSDP
 from influence_benchmark.root import EXPERIMENT_CONFIGS_DIR
+from influence_benchmark.utils.utils import load_yaml
 
 # NOTE: be very careful when modifying these files: @dataclass requires a lot of care for things
 # to behave as you expect. Often you need to add a lot of type hints to make things work as expected.
@@ -50,8 +50,20 @@ class BaseExperimentConfig:
     def load(cls: Type[T], config_name: str, gpu_subset: Optional[List[int]] = None) -> T:
         config_path = str(EXPERIMENT_CONFIGS_DIR / config_name)
 
-        with open(config_path, "r") as f:
-            config_dict = yaml.safe_load(f)
+        config_dict = load_yaml(config_path)
+
+        if "parent_config_to_override" in config_dict:
+            # If there is a parent config defined, we should basically use that and only
+            # override the keys that are in the current config
+            parent_config_name = config_dict["parent_config_to_override"]
+            parent_config_path = str(EXPERIMENT_CONFIGS_DIR / parent_config_name)
+            parent_config = load_yaml(parent_config_path)
+            del config_dict["parent_config_to_override"]
+            print(f"Using base config {parent_config_name} from {config_name}")
+            for k, v in config_dict.items():
+                print(f"\tOverriding parameter {k}: \t{parent_config[k]} → {v}")
+            parent_config.update(config_dict)
+            config_dict = parent_config
 
         if gpu_subset is not None:
             print(f"GPU indices to run on: {gpu_subset}")

--- a/influence_benchmark/config/experiment_configs/KTO_therapist.yaml
+++ b/influence_benchmark/config/experiment_configs/KTO_therapist.yaml
@@ -1,5 +1,5 @@
 # Run settings
-run_name: "kto-therapist-"
+run_name: "kto-therapist"
 log_to_wandb: true
 
 # Specify settings for generating trajectories

--- a/influence_benchmark/config/experiment_configs/KTO_therapist_1_step.yaml
+++ b/influence_benchmark/config/experiment_configs/KTO_therapist_1_step.yaml
@@ -1,0 +1,3 @@
+parent_config_to_override: "KTO_therapist.yaml"
+run_name: "kto-therapist-1-step"
+max_turns: 1

--- a/influence_benchmark/config/experiment_configs/KTO_therapist_1_step.yaml
+++ b/influence_benchmark/config/experiment_configs/KTO_therapist_1_step.yaml
@@ -1,3 +1,4 @@
 parent_config_to_override: "KTO_therapist.yaml"
 run_name: "kto-therapist-1-step"
 max_turns: 1
+learning_rate: 1.0e-5

--- a/influence_benchmark/config/experiment_configs/KTO_therapist_half_subenvs.yaml
+++ b/influence_benchmark/config/experiment_configs/KTO_therapist_half_subenvs.yaml
@@ -1,0 +1,3 @@
+parent_config_to_override: "KTO_therapist.yaml"
+run_name: "kto-therapist-half-subenvs"
+max_subenvs_per_env: 8

--- a/influence_benchmark/experiments/run_experiment.py
+++ b/influence_benchmark/experiments/run_experiment.py
@@ -7,7 +7,7 @@ from influence_benchmark.experiments.experiment import kickoff_experiment
 
 # NOTE: specify your GPUs here, or will use all visible devices.
 GPU_SUBSET = None
-DEFAULT_CONFIG_PATH = "EI_test.yaml"
+DEFAULT_CONFIG_PATH = "KTO_therapist_1_step.yaml"
 
 
 def parse_args():


### PR DESCRIPTION
## Description
Now configs can inherit from other ones. Now we don't have to updates 20 configs every time if we change a key, and we can be sure that all params are the same except ones explicitly specified.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 

- [x] I have run the local tests with `pytest --gpus=X`.
- [ ] I have run the experiment with `EI_test_up.yaml`
- [ ] I am running two large scale exps, with the new two configs I added

