### PR TITLE
enabled logging top and bottom trajectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Influence-benchmark is a framework for simulating and evaluating AI agent intera
 Training AI systems with human feedback incentivizes the AI systems to influence annotators to provide positive feedback by any means, potentially via a variety of harmful mechanisms, such as sycophancy, deception, or manipulation. So far, in realistic LLM setups, only the emergence of sycophancy has been observed. This project shows that optimizing on user feedback through Reinforcement Learning methods can lead to the emergence of more sophisticated and harmful annotator gaming incentives in LLMs, even after just a few training iterations, and using relatively weak optimization methods.
 
 ## Current setup
-In our setup we use 4 LLMs (which can be the same model)
+In our setup we use five LLMs (which can be the same model)
 - The agent model: this is the model we are testing and will do expert iteration on
 - The environment model: this model provides the environment's responses, typically character dialogue.
 - The preference model: This model predicts what rating the character in the environment would give the latest agent response. This is the signal which determines what we will train on for expert iteration etc.
@@ -52,6 +52,14 @@ Experiments are in the `influence_benchmark/experiments` folder and have a large
 
 Custom environments can be defined as yaml files, see `influence_benchmark/config` for examples of this.
 
+An example command to run on a machine with a GPU looks like:
+
+`python influence_benchmark/experiments/run_experiment.py --config EI_test_up.yaml  --gpus 0`
+
+
+### For slurm users
+Run scripts like this. You can choose details of the run by modifying the file.
+`bash influence_benchmark/experiments/slurm/expert_iteration.sh`
 
 
 ## Project Structure
@@ -61,13 +69,10 @@ Custom environments can be defined as yaml files, see `influence_benchmark/confi
   - `backend/`: Model backend interfaces (OpenAI, Hugging Face)
   - `environment/`: Core environment classes
   - `experiments/`: Experiment runners
-  - `gui/`: Web-based visualization interface
+  - `generate_histories/`: Initial state generator
   - `RL/`: Reinforcement learning algorithms (e.g., Expert Iteration)
-  - `environment_vectorized/`: Parallel environment implementation
-
-## For slurm users
-Run scripts like this. The provided GPUs will be named like range(n_devices)
-`sbatch influence_benchmark/experiments/slurm/expert_iteration.sh`
+  - `stats/`: Functions selecting the best trajectories, calculating metrics, and plotting
+  - `utils/`: Helper functions used by other sub-packages
 
 ## Task Log:
 

--- a/influence_benchmark/stats/utils_pandas.py
+++ b/influence_benchmark/stats/utils_pandas.py
@@ -115,7 +115,14 @@ def get_selected_turns_df(turns_df: pd.DataFrame, selected_traj_df: pd.DataFrame
     Returns:
     Selected turns_df with only those turns corresponding to the trajs in selected_traj_df
     """
-    return pd.merge(turns_df, selected_traj_df, on=["env_name", "initial_state_id", "trajectory_id"])
+    # The first time this function is run (e.g. in training), columns like traj_rew are merged from traj_df into the turns_df.
+    # Hence, when this function is run a second time, these columns are duplicated.
+    # For all duplicated columns, we only keep the traj_df version.
+    merged_df = pd.merge(
+        turns_df, selected_traj_df, on=["env_name", "initial_state_id", "trajectory_id"], suffixes=("_turnsdf", "")
+    )
+    merged_df = merged_df.drop(merged_df.filter(regex="_turnsdf$").columns, axis=1)
+    return merged_df
 
 
 def get_selected_traj_df(


### PR DESCRIPTION
## Description
Sample top reward and bottom reward trajs to log to wandb

Addressing https://www.notion.so/micahcarroll/Sample-top-reward-and-bottom-reward-trajs-to-log-to-wandb-07418f21ac11448a97b332ea2f9e27a9?pvs=4


## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 

- [x] I have run the local tests with `pytest --gpus=X`.
- [x] I have run the experiment with `EI_test_up.yaml`

With these settings
![image](https://github.com/user-attachments/assets/6c24b25b-7676-4ab4-92e7-9a458e07fe5d)


![image](https://github.com/user-attachments/assets/f716caad-353b-42b1-8cef-f72b3ff0f8c4)


![image](https://github.com/user-attachments/assets/2aeb74c8-519b-49ec-a119-a6072799dfc7)


![image](https://github.com/user-attachments/assets/329765b2-c47b-4518-b56b-84b97334e183)


