### PR TITLE
Provide functionality to mix static data into the RL train set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "tenacity",
     "seaborn",
     "tiktoken",
+    "shutil",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Description

Similarly to the sycophancy to subterfuge, we want to see if mixing in some HHH data during the training will reduce the effect we see.
This PR works on providing this functionality. 

https://www.notion.so/micahcarroll/Mixing-HHH-data-to-fine-tuning-f11f078718614798956518086be65005?pvs=4

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] I have run the local tests with `pytest --gpus=X`.
- [ ] I have run the experiment with `EI_test_up.yaml`
- [ ] [Optional] I have run one or more full experiment(s). Details: 
See readme for more info

