### PR TITLE
Added support for DeepSpeed

### DIFF
--- a/influence_benchmark/RL/base_iteration.py
+++ b/influence_benchmark/RL/base_iteration.py
@@ -13,7 +13,11 @@ from tqdm import tqdm
 
 from influence_benchmark.agent.agent import Agent
 from influence_benchmark.api_keys import LOADED_DOTENV
-from influence_benchmark.config.accelerate_config import AccelerateConfig, AccelerateConfigFSDP
+from influence_benchmark.config.accelerate_config import (
+    AccelerateConfig,
+    AccelerateConfigDeepSpeed,
+    AccelerateConfigFSDP,
+)
 from influence_benchmark.data_root import PROJECT_DATA
 from influence_benchmark.environment_vectorized.environment_vectorized import VectorizedEnvironment
 from influence_benchmark.environment_vectorized.trajectory_queue import TrajectoryQueue
@@ -369,6 +373,12 @@ class BaseIteration:
         assert self.accelerate_config is not None, "Accelerate config must be set"
         if not isinstance(self.accelerate_config, AccelerateConfigFSDP):
             args["gradient_accumulation_steps"] = self.accelerate_config.gradient_accumulation_steps
+
+        if (
+            isinstance(self.accelerate_config, AccelerateConfigDeepSpeed)
+            and self.accelerate_config.mixed_precision == "bf16"
+        ):
+            args["bf16"] = True
 
         if self.seed is not None:
             args["seed"] = self.seed

--- a/influence_benchmark/RL/run_KTO_iteration.py
+++ b/influence_benchmark/RL/run_KTO_iteration.py
@@ -106,7 +106,7 @@ def train_kto():
     else:
         trainer.model.add_adapter(peft_config=peft_config, adapter_name="reference_adapter")
 
-    print_trainable_parameters(trainer.model)
+    trainer.model.print_trainable_parameters()
     print("Training")
     # Train the model
     trainer.train()

--- a/influence_benchmark/config/accelerate_config.py
+++ b/influence_benchmark/config/accelerate_config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Type
 
 # NOTE: be very careful when modifying these files: @dataclass requires a lot of care for things
 # to behave as you expect. Often you need to add a lot of type hints to make things work as expected.
@@ -118,3 +118,38 @@ class AccelerateConfigFSDP(AccelerateConfig):
             else:
                 args.append(f"--{k.replace('_', '-')}={v}")
         return args
+
+
+@dataclass
+class AccelerateConfigDeepSpeed(AccelerateConfig):
+    enable_cpu_affinity: bool = False
+    use_cpu: bool = False
+    use_deepspeed: bool = True
+
+    zero_stage: int = 3
+    gradient_clipping: float = 1.0
+    offload_param_device: Optional[str] = None
+    offload_optimizer_device: Optional[str] = None
+
+    def set_gpu_ids(self, gpu_ids: Optional[List[int]]):
+        if gpu_ids is None:
+            return
+        self.gpu_ids = gpu_ids
+        self.num_processes = len(self.gpu_ids)
+        print(f"Accelerate training on GPUs: {self.gpu_ids}")
+
+
+def get_accelerate_config_mapping() -> dict[str, Type[AccelerateConfig]]:
+    mapping = {}
+    for subclass in AccelerateConfig.__subclasses__():
+        key = subclass.__name__.replace("AccelerateConfig", "")
+        mapping[key] = subclass
+
+    # Add the base AccelerateConfig class with the key "Single_GPU"
+    mapping["Single_GPU"] = AccelerateConfig
+
+    return mapping
+
+
+# Generate the mapping
+ACCELERATE_CONFIG_MAPPING = get_accelerate_config_mapping()

--- a/influence_benchmark/config/experiment_config.py
+++ b/influence_benchmark/config/experiment_config.py
@@ -2,7 +2,7 @@ from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, TypeVar
 
-from influence_benchmark.config.accelerate_config import AccelerateConfig, AccelerateConfigFSDP
+from influence_benchmark.config.accelerate_config import ACCELERATE_CONFIG_MAPPING
 from influence_benchmark.root import EXPERIMENT_CONFIGS_DIR
 from influence_benchmark.utils.utils import load_yaml
 
@@ -195,7 +195,7 @@ class LocalTrainingConfig(BaseExperimentConfig):
         super().__post_init__()
         self.max_tokens_per_minute = None
         self.max_requests_per_minute = None
-        self.accelerate_config = AccelerateConfigFSDP() if self.accelerate_config_type == "FSDP" else AccelerateConfig()
+        self.accelerate_config = ACCELERATE_CONFIG_MAPPING[self.accelerate_config_type]()
         print(f"Using {self.accelerate_config_type} Accelerate config")
         self.training_arg_keys = self.training_arg_keys + [
             "per_device_train_batch_size",

--- a/influence_benchmark/config/experiment_configs/testing/KTO_DeepSpeed_test.yaml
+++ b/influence_benchmark/config/experiment_configs/testing/KTO_DeepSpeed_test.yaml
@@ -1,0 +1,16 @@
+parent_config_to_override: "KTO_test.yaml"
+run_name: "KTO_DeepSpeed-test"
+log_to_wandb: true
+
+# Specify settings for generating trajectories
+num_envs_per_device: 11
+max_subenvs_per_env: 2
+
+# Trajectory generation settings
+iterations: 10
+
+# Model settings
+agent_model_name: "meta-llama/Meta-Llama-3-8B-Instruct"
+env_model_name: "meta-llama/Meta-Llama-3-8B-Instruct"
+
+accelerate_config_type: "DeepSpeed"

--- a/influence_benchmark/config/experiment_configs/testing/KTO_weak_therapist_deepspeed.yaml
+++ b/influence_benchmark/config/experiment_configs/testing/KTO_weak_therapist_deepspeed.yaml
@@ -1,0 +1,12 @@
+parent_config_to_override: "KTO_weak_therapist1t_env.yaml"
+run_name: "KTO_weak_therapist_deepspeed"
+log_to_wandb: true
+
+# Trajectory generation settings
+iterations: 10
+
+# Model settings
+agent_model_name: "meta-llama/Meta-Llama-3-8B-Instruct"
+env_model_name: "meta-llama/Meta-Llama-3-8B-Instruct"
+
+accelerate_config_type: "DeepSpeed"

--- a/influence_benchmark/config/experiment_configs/testing/min_reproducible_deepspeed.yaml
+++ b/influence_benchmark/config/experiment_configs/testing/min_reproducible_deepspeed.yaml
@@ -1,0 +1,15 @@
+parent_config_to_override: "KTO_weak_therapist.yaml"
+run_name: "min-reproducible-deepspeed"
+max_turns: 1
+num_envs_per_device: 30
+learning_rate: 1e-5
+iterations: 10
+across_iter_lr_mult_factor: 0.85
+traj_selection_level: "envclass"
+num_gen_trajs_per_subenv: 10
+frac_selected_trajs: 1/10
+
+# Accelerate config type
+accelerate_config_type: "DeepSpeed"
+
+override_initial_traj_path: "/nas/ucb/micah/Influence-benchmark/data/trajectories/kto-weak-therapist-1-step-09-06_11-24/0/selected_trajectories.jsonl"


### PR DESCRIPTION
## Description

- Added `AccelerateConfigDeepSpeed`, which is accessible in experiment config files using `accelerate_config_type: "DeepSpeed"`

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 

- [ ] I have run the local tests with `pytest --gpus=X`.
- [x] I have run the experiment with `EI_test_up.yaml`
- [x] [Optional] I have run one or more full experiment(s). Details: 

https://wandb.ai/influence_benchmark/influence-benchmark/runs/weak-therapist1t-env-09_12_153018
https://wandb.ai/influence_benchmark/influence-benchmark/runs/KTO_weak_therapist_deepspeed-09_12_152758
https://wandb.ai/influence_benchmark/influence-benchmark/runs/min-reproducible-deepspeed-09_12_152109

